### PR TITLE
Feature/Random generated admin tokens

### DIFF
--- a/web3_reverse_proxy/service/http/adminserver.py
+++ b/web3_reverse_proxy/service/http/adminserver.py
@@ -1,20 +1,48 @@
 import json
 import random
 import re
-import socket
 import socketserver
 import string
 import threading
+import secrets
+import hashlib
+
 from http.server import BaseHTTPRequestHandler
 
 from web3_reverse_proxy.config.conf import Config
 from web3_reverse_proxy.service.admin.serviceadmin import RPCServiceAdmin
 
 
+# TODO: Whole auth is operating under bastardized concept of basic authorizations scheme with random tokens
+# It's insecure for anything outside of local network and should be expanded to legitimate security measures
+class AdminServerAuthentication():
+    def __init__(self) -> None:
+        self.salt = secrets.token_hex(8)
+        self.admin_token_hash = None
+
+    def hash(self, secret: str) -> str:
+        salted_secret = secret + self.salt
+        hashed = hashlib.sha256(salted_secret.encode())
+        return hashed.hexdigest()
+
+    def authenticate(self, secret) -> bool:
+        if self.admin_token_hash is None:
+            raise Exception("Authentication token was not generated")
+        return self.hash(secret) == self.admin_token_hash
+
+    def generate_secret(self) -> str:
+        return "".join(random.choice(string.ascii_letters + string.digits) for _ in range(32))
+
+    def create_auth_token(self) -> str:
+        auth_token = self.generate_secret()
+        self.admin_token_hash = self.hash(auth_token)
+        return auth_token
+
+
 # https://gist.github.com/scimad/ae0196afc0bade2ae39d604225084507
 class AdminServerRequestHandler(BaseHTTPRequestHandler):
 
-    def get_valid_host_page(self) -> bytes:
+    def get_valid_host_page(self, auth_token: str) -> bytes:
         assert isinstance(self.server, AdminHTTPServer)
 
         assert "Host" in self.headers
@@ -27,44 +55,49 @@ class AdminServerRequestHandler(BaseHTTPRequestHandler):
             # if Config.PUBLIC_SERVICE:
             #     ip = my_public_ip()
             raw_page = f.read().decode("utf-8")
-            host = f'return "http://{host}/{self.server.auth_token}";'
+            host = f'return "http://{host}/";'
             host_re = r"//HOST_MARKER_S[\s\w.]+.+\s+//HOST_MARKER_E"
+            auth_token_expr = f'return "{auth_token}";'
+            auth_token_re = r"//TOKEN_MARKER_S[\s\w.]+.+\s+//TOKEN_MARKER_E"
 
-            updated_page = re.sub(host_re, host, raw_page)
+            updated_page = re.sub(auth_token_re, auth_token_expr, re.sub(host_re, host, raw_page))
 
             return updated_page.encode("utf-8")
 
     def do_GET(self):
-        if self.path == "/6a5d70f03252a227a6b8292ac80b33d4b1740833a65e31175":
-            self.send_response(200)
-            self.send_header("Content-type", "text/html")
-            self.end_headers()
-
-            self.wfile.write(self.get_valid_host_page())
-
-            # # Test how a web browser handles partial update of a web page
-            # data = bytearray(f.read())
-            # i = 0
-            # while i < len(data):
-            #     self.wfile.write(data[i:i+250])
-            #     i += 250
-            #     time.sleep(0.1)
-        elif self.path == "/favicon.ico":
+        if self.path == "/favicon.ico":
             self.send_response(200)
             self.send_header("Content-Type", "image/x-icon")
             self.send_header("Content-Length", "0")
             self.end_headers()
         else:
-            self.send_response(401)
+            self.send_response(200)
             self.send_header("Content-type", "text/html")
             self.end_headers()
 
-            response = (
-                "<!DOCTYPE html><html><head><title>Unauthorized</title></head><body><h1>You are not authorized "
-                "to access this page</h1></body></html>"
-            )
+            # Get auth token from query params for accessing admin portal with browser
+            auth_token = self.path.split("?token=")[-1]
+            if (self.server.auth.authenticate(auth_token)):
+                self.wfile.write(self.get_valid_host_page(auth_token))
 
-            self.wfile.write(response.encode("UTF-8"))
+                # # Test how a web browser handles partial update of a web page
+                # data = bytearray(f.read())
+                # i = 0
+                # while i < len(data):
+                #     self.wfile.write(data[i:i+250])
+                #     i += 250
+                #     time.sleep(0.1)
+            else:
+                self.send_response(401)
+                self.send_header("Content-type", "text/html")
+                self.end_headers()
+
+                response = (
+                    "<!DOCTYPE html><html><head><title>Unauthorized</title></head><body><h1>You are not authorized "
+                    "to access this page</h1></body></html>"
+                )
+
+                self.wfile.write(response.encode("UTF-8"))
 
     def log_request(self, code: int | str = ..., size: int | str = ...) -> None:
         pass
@@ -80,12 +113,15 @@ class AdminServerRequestHandler(BaseHTTPRequestHandler):
         self.send_header("Content-type", "application/json")
         self.end_headers()
 
-        if self.path == self.server.auth_token:
+        if self.server.auth.authenticate(self.get_auth_token()):
             if "method" in json_data and "params" in json_data:
                 res = admin.call_by_method(json_data["method"], json_data["params"])
                 self.wfile.write(json.dumps(res if res is not None else {}).encode())
         else:
             self.wfile.write(json.dumps({}).encode())
+
+    def get_auth_token(self) -> str:
+        return self.headers.get('Authorization', '').partition(" ")[-1]
 
 
 class AdminHTTPServer(socketserver.TCPServer):
@@ -98,6 +134,7 @@ class AdminHTTPServer(socketserver.TCPServer):
         self.auth_token = "/" + "".join(
             random.choice(string.ascii_letters + string.digits) for _ in range(32)
         )
+        self.auth = AdminServerAuthentication()
 
     # def server_bind(self) -> None:
     #     self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
@@ -115,10 +152,15 @@ class AdminHTTPServerThread(threading.Thread):
         print(
             f"HTTP Admin server listening on: {self.server.server_address[0]}:{self.server.server_address[1]}"
         )
+        # TODO: Storage for credentials
+        auth_token = self.server.auth.create_auth_token()
         print(
-            f"HTTP Admin server url: "
-            f"http://<IP addr>:{self.server.server_address[1]}/6a5d70f03252a227a6b8292ac80b33d4b1740833a65e31175"
+            "Admin auth token: "
+            f"{auth_token}"
         )
+        print("Use it with 'Authorization' header for POST requests")
+        print(f"Access admin portal with")
+        print(f"{self.server.server_address[0]}:{self.server.server_address[1]}/?token={auth_token}")
         super().start()
 
     def run(self):


### PR DESCRIPTION
Removes secret from code and creates temporal, random auth tokens for admin service.

Admin request handler now reads token from 'Authorization' header on POST

Server stores salted hash of token to compare against input

Requires admin page update: https://github.com/Web3-Pi/web3-reverse-proxy-admin/pull/1