### PR TITLE
FEAT: DISPATCHER: embed tunnel server

### DIFF
--- a/web3pi_proxy/core/proxy.py
+++ b/web3pi_proxy/core/proxy.py
@@ -165,6 +165,7 @@ class Web3RPCProxy:
             except Exception as error:
                 self.__logger.error("%s: %s", error.__class__, error)
                 self.__logger.error("Failed to establish endpoint connection")
+                self.__logger.exception(error)
                 cs.send_all(
                     ErrorResponses.connection_error(req.id)
                 )  # TODO: detect wether client connection is closed

--- a/web3pi_proxy/core/rpc/node/endpoint_pool/endpoint_connection_pool.py
+++ b/web3pi_proxy/core/rpc/node/endpoint_pool/endpoint_connection_pool.py
@@ -14,7 +14,7 @@ from web3pi_proxy.core.rpc.node.rpcendpoint.connection.endpoint_connection_handl
     EndpointConnectionHandler,
 )
 from web3pi_proxy.core.rpc.node.rpcendpoint.connection.endpointconnection import (
-    EndpointConnection,
+    EndpointConnection, EndpointConnectionImpl,
 )
 from web3pi_proxy.core.rpc.node.rpcendpoint.endpointimpl import RPCEndpoint
 from web3pi_proxy.core.rpc.request.rpcrequest import RPCRequest
@@ -135,7 +135,8 @@ class EndpointConnectionPool(ConnectionPool):
             try:
                 connection.close()
             except Exception as ex:
-                self.__logger.error(f"Error while closing a connection", ex)
+                self.__logger.error("Error while closing a connection")
+                self.__logger.exception(ex)
 
     def __run_cleanup_thread(self) -> None:
         while True:
@@ -167,6 +168,10 @@ class EndpointConnectionPool(ConnectionPool):
     def __get_connection(self) -> EndpointConnection:
         return self.connections.get_nowait()
 
+    def new_connection(self) -> EndpointConnection:
+        """to be used only by overriding classes"""
+        return EndpointConnectionImpl(self.endpoint)
+
     def __update_status(self, status: str):
         self.status = status
         self.__logger.debug(f"Changed status to {status}")
@@ -180,7 +185,7 @@ class EndpointConnectionPool(ConnectionPool):
             self.__lock.release()
             self.__logger.debug("No existing connections available, establishing new connection")
             try:
-                connection = EndpointConnection(self.endpoint)
+                connection = self.new_connection()
             except Exception as error:
                 self.stats.register_error_on_connection_creation()
                 raise error
@@ -216,6 +221,9 @@ class EndpointConnectionPool(ConnectionPool):
 
     def is_active(self):
         return self.status == self.PoolStatus.ACTIVE.value
+
+    def is_open(self):
+        return self.status == self.PoolStatus.ACTIVE.value or self.status == self.PoolStatus.DISABLED.value
 
     def disable(self):
         with self.__lock:

--- a/web3pi_proxy/core/rpc/node/endpoint_pool/tunnel_connection_pool.py
+++ b/web3pi_proxy/core/rpc/node/endpoint_pool/tunnel_connection_pool.py
@@ -1,0 +1,56 @@
+import socket
+
+from web3pi_proxy.config import Config
+from web3pi_proxy.core.rpc.node.endpoint_pool.endpoint_connection_pool import EndpointConnectionPool
+from web3pi_proxy.core.rpc.node.rpcendpoint.connection.endpointconnection import EndpointConnection
+from web3pi_proxy.core.rpc.node.rpcendpoint.connection.tunnelendpointconnection import TunnelEndpointConnection
+from web3pi_proxy.core.rpc.node.rpcendpoint.endpointimpl import RPCEndpoint
+
+from web3pi_proxy.utils.logger import get_logger
+
+
+class TunnelConnectionPool(EndpointConnectionPool):
+
+    def __init__(
+        self,
+        endpoint: RPCEndpoint,
+    ):
+        super().__init__(endpoint)
+        self.__logger = get_logger(f"TunnelConnectionPool.{id(self)}")
+
+        self.tunnel_api_key = endpoint.conn_descr.extras["tunnel_service_auth_key"]
+
+        tunnel_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        tunnel_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        tunnel_socket.bind((Config.PROXY_LISTEN_ADDRESS, endpoint.conn_descr.extras["tunnel_proxy_establish_port"]))
+        tunnel_socket.listen(Config.LISTEN_BACKLOG_PARAM)
+        self.tunnel_socket = tunnel_socket
+
+        self.tunnel_service_socket = None
+
+        self.status = self.PoolStatus.DISABLED.value
+
+    def new_connection(self) -> EndpointConnection:
+
+        def connection_factory() -> socket:  # TODO is it worth to move it to object level and reuse?
+            self.__logger.debug("Creating socket")
+            self.tunnel_service_socket.sendall(b"NEWCONN")
+            new_conn_sock, new_conn_addr = self.tunnel_socket.accept()
+            self.__logger.debug("Finished connecting socket")
+            return new_conn_sock
+
+        return TunnelEndpointConnection(self.endpoint, connection_factory)
+
+    def new_tunnel_service_socket(self, tunnel_service_socket: socket):
+        with self._EndpointConnectionPool__lock:
+            self.tunnel_service_socket = tunnel_service_socket
+            self.status = self.PoolStatus.ACTIVE.value
+
+    def close(self) -> None:
+        super().close()
+        self.tunnel_socket.close()
+        self.tunnel_socket = None
+        if self.tunnel_service_socket:
+            self.tunnel_service_socket.close()
+            self.tunnel_service_socket = None
+

--- a/web3pi_proxy/core/rpc/node/rpcendpoint/connection/connectiondescr.py
+++ b/web3pi_proxy/core/rpc/node/rpcendpoint/connection/connectiondescr.py
@@ -12,6 +12,7 @@ class EndpointConnectionDescriptor:
     auth_key: str
     is_ssl: bool
     url: str
+    extras: dict
 
     @classmethod
     def from_url(cls, url) -> EndpointConnectionDescriptor | None:
@@ -37,4 +38,15 @@ class EndpointConnectionDescriptor:
             else:
                 return None
 
-        return EndpointConnectionDescriptor(host, int(port), auth_key, is_ssl, url)
+        return EndpointConnectionDescriptor(host, int(port), auth_key, is_ssl, url, dict())
+
+    @classmethod
+    def from_dict(cls, conf: dict) -> EndpointConnectionDescriptor | None:
+        url: str = conf["url"]
+        conn_descr = cls.from_url(url)
+        if not conn_descr:
+            return None
+        conn_descr.extras = conf.copy()
+        del conn_descr.extras["name"]
+        del conn_descr.extras["url"]
+        return conn_descr

--- a/web3pi_proxy/core/rpc/node/rpcendpoint/connection/endpointconnection.py
+++ b/web3pi_proxy/core/rpc/node/rpcendpoint/connection/endpointconnection.py
@@ -32,7 +32,7 @@ class EndpointConnection:
         self.endpoint = endpoint
 
         self.__logger.debug(f"Creating socket for endpoint: {endpoint}")
-        self.socket = self.__create_socket()
+        self.socket = self.create_socket()
         self.__logger.debug(f"Socket created for description: {self.conn_descr}")
 
         self.req_sender = RequestSender(
@@ -51,17 +51,16 @@ class EndpointConnection:
     def ip(self) -> str:
         return self.socket.get_peer_name()[0]
 
-    def __create_socket(self) -> BaseSocket:
-        return BaseSocket.create_socket(
-            self.conn_descr.host, self.conn_descr.port, self.conn_descr.is_ssl
-        )
+    def create_socket(self) -> BaseSocket:
+        """Internal function, do not call directly"""
+        pass
 
     def close(self) -> None:
-        self.socket.close()
+        pass
 
     def reconnect(self) -> None:
         self.close()
-        self.socket = self.__create_socket()
+        self.socket = self.create_socket()
         self.req_sender = RequestSender(
             self.socket, self.conn_descr.host, self.conn_descr.auth_key
         )
@@ -71,3 +70,15 @@ class EndpointConnection:
         self, request_bytes: bytearray, response_bytes: bytearray
     ) -> None:
         self.endpoint.update_stats(request_bytes, response_bytes)
+
+
+class EndpointConnectionImpl(EndpointConnection):
+
+    def close(self) -> None:
+        self.socket.close()
+
+    def create_socket(self) -> BaseSocket:
+        return BaseSocket.create_socket(
+            self.conn_descr.host, self.conn_descr.port, self.conn_descr.is_ssl
+        )
+

--- a/web3pi_proxy/core/rpc/node/rpcendpoint/connection/tunnelendpointconnection.py
+++ b/web3pi_proxy/core/rpc/node/rpcendpoint/connection/tunnelendpointconnection.py
@@ -1,0 +1,23 @@
+import socket
+from typing import Callable
+
+from web3pi_proxy.core.rpc.node.rpcendpoint.connection.endpointconnection import EndpointConnection
+from web3pi_proxy.core.rpc.node.rpcendpoint.endpointimpl import RPCEndpoint
+from web3pi_proxy.core.sockets.basesocket import BaseSocket
+
+
+class TunnelEndpointConnection(EndpointConnection):
+
+    def __init__(self, endpoint: RPCEndpoint, connection_factory: Callable) -> None:
+        self.connection_factory = connection_factory
+        super().__init__(endpoint)
+
+    def close(self) -> None:
+        self.socket.close()
+
+    def create_socket(self) -> BaseSocket:
+        s_dst: socket = self.connection_factory()
+        return BaseSocket.wrap_socket(
+            s_dst, self.conn_descr.host, self.conn_descr.is_ssl
+        )
+

--- a/web3pi_proxy/core/sockets/basesocket.py
+++ b/web3pi_proxy/core/sockets/basesocket.py
@@ -75,9 +75,14 @@ class BaseSocket:
 
         s_dst.settimeout(5.0)  # TODO parametrize?
         s_dst.connect((host_ip, port))
-        s_dst.settimeout(None)
 
         cls.__logger.debug("Finished connecting socket")
+
+        return cls.wrap_socket(s_dst, host, is_ssl)
+
+    @classmethod
+    def wrap_socket(cls, s_dst: socket, host: str, is_ssl: bool) -> BaseSocket:
+        s_dst.settimeout(None)
 
         if is_ssl:
             context = ssl.create_default_context()
@@ -86,3 +91,4 @@ class BaseSocket:
         res = BaseSocket(s_dst)
 
         return res
+

--- a/web3pi_proxy/service/endpoints/endpoint_manager.py
+++ b/web3pi_proxy/service/endpoints/endpoint_manager.py
@@ -54,7 +54,7 @@ class EndpointManagerService:
         return nodes_data
 
     def add_endpoint(self, name: str, url: str) -> RPCEndpoint | dict:
-        descriptor = EndpointConnectionDescriptor.from_url(url)
+        descriptor = EndpointConnectionDescriptor.from_url(url)  # TODO from_dict
         try:
             endpoint = self.endpoint_pool_manager.add_pool(name, descriptor)
         except PoolAlreadyExistsError as error:
@@ -71,7 +71,7 @@ class EndpointManagerService:
         return endpoint
 
     def update_endpoint(self, name: str, url: str) -> RPCEndpoint | dict:
-        descriptor = EndpointConnectionDescriptor.from_url(url)
+        descriptor = EndpointConnectionDescriptor.from_url(url)  # TODO from_dict
         try:
             self.endpoint_pool_manager.remove_pool(name)
         except PoolDoesNotExistError as error:

--- a/web3pi_proxy/service/providers/serviceprovider.py
+++ b/web3pi_proxy/service/providers/serviceprovider.py
@@ -42,7 +42,7 @@ class ServiceComponentsProvider:
         descriptors = [
             (
                 entrypoint["name"],
-                EndpointConnectionDescriptor.from_url(entrypoint["url"]),
+                EndpointConnectionDescriptor.from_dict(entrypoint),
             )
             for entrypoint in endpoint_config
         ]


### PR DESCRIPTION
The point is that a part of eth endpoints in the web3proxy can be configured as connected via tunnel. 
For that a new class of connection pool is developed: TunnelConnectionPool.
A web3pi tunnel, a server tunnel part, is used.

Closes #75 